### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "reedline-repl-rs"
 version = "1.0.2"
-authors = ["Artur Hallmann <arturh@arturh.de>", "Jack Lund <jackl@geekheads.net>"]
+authors = [
+    "Artur Hallmann <arturh@arturh.de>",
+    "Jack Lund <jackl@geekheads.net>",
+]
 description = "Library to generate a fancy REPL for your application based on reedline and clap"
 license = "MIT"
 repository = "https://github.com/arturh85/reedline-repl-rs"
@@ -14,15 +17,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reedline = "0.6.0"
-nu-ansi-term = { version = "0.45.1" }
-crossterm = { version = "0.23.2" }
+reedline = "0.13.0"
+nu-ansi-term = { version = "0.46.0" }
+crossterm = { version = "0.25.0" }
 yansi = "0.5.1"
 regex = "1"
-clap = "3"
+clap = "4"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] } # only for async example
+tokio = { version = "1", features = [
+    "macros",
+    "rt-multi-thread",
+] } # only for async example
 
 [target.'cfg(windows)'.dependencies]
 winapi-util = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reedline-repl-rs"
-version = "1.0.2"
+version = "1.0.3"
 authors = [
     "Artur Hallmann <arturh@arturh.de>",
     "Jack Lund <jackl@geekheads.net>",

--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ Features:
 Basic example code:
 
 ```rust
+//! Minimal example
 use reedline_repl_rs::clap::{Arg, ArgMatches, Command};
 use reedline_repl_rs::{Repl, Result};
 
 /// Write "Hello" with given name
 fn hello<T>(args: ArgMatches, _context: &mut T) -> Result<Option<String>> {
-    Ok(Some(format!("Hello, {}", args.value_of("who").unwrap())))
+    Ok(Some(format!(
+        "Hello, {}",
+        args.get_one::<String>("who").unwrap()
+    )))
 }
 
 fn main() -> Result<()> {
@@ -39,7 +43,7 @@ fn main() -> Result<()> {
             Command::new("hello")
                 .arg(Arg::new("who").required(true))
                 .about("Greetings!"),
-            hello
+            hello,
         );
     repl.run()
 }
@@ -73,6 +77,14 @@ MyApp〉hello Friend
 Hello, Friend
 MyApp〉
 ```
+
+## Testing
+
+``` shell
+cargo test --features async
+```
+
+Will run the doc tests (compiling the examples). Notice, the `examples/async.rs` requires the `async` feature.
 
 ## Thanks
 

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -4,7 +4,10 @@ use reedline_repl_rs::{Repl, Result};
 
 /// Write "Hello" with given name
 async fn hello<T>(args: ArgMatches, _context: &mut T) -> Result<Option<String>> {
-    Ok(Some(format!("Hello, {}", args.value_of("who").unwrap())))
+    Ok(Some(format!(
+        "Hello, {}",
+        args.get_one::<String>("who").unwrap()
+    )))
 }
 
 /// Called after successful command execution, updates prompt with returned Option

--- a/examples/custom_keybinding.rs
+++ b/examples/custom_keybinding.rs
@@ -1,12 +1,15 @@
 //! Example with custom Keybinding
-use crossterm::event::{KeyCode, KeyModifiers};
 use reedline::{EditCommand, ReedlineEvent};
+use reedline::{KeyCode, KeyModifiers};
 use reedline_repl_rs::clap::{Arg, ArgMatches, Command};
 use reedline_repl_rs::{Repl, Result};
 
 /// Write "Hello" with given name
 fn hello<T>(args: ArgMatches, _context: &mut T) -> Result<Option<String>> {
-    Ok(Some(format!("Hello, {}", args.value_of("who").unwrap())))
+    Ok(Some(format!(
+        "Hello, {}",
+        args.get_one::<String>("who").unwrap()
+    )))
 }
 
 fn main() -> Result<()> {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,7 +4,10 @@ use reedline_repl_rs::{Repl, Result};
 
 /// Write "Hello" with given name
 fn hello<T>(args: ArgMatches, _context: &mut T) -> Result<Option<String>> {
-    Ok(Some(format!("Hello, {}", args.value_of("who").unwrap())))
+    Ok(Some(format!(
+        "Hello, {}",
+        args.get_one::<String>("who").unwrap()
+    )))
 }
 
 fn main() -> Result<()> {

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -4,7 +4,10 @@ use reedline_repl_rs::{initialize_repl, Repl, Result};
 
 /// Write "Hello" with given name
 fn hello<T>(args: ArgMatches, _context: &mut T) -> Result<Option<String>> {
-    Ok(Some(format!("Hello, {}", args.value_of("who").unwrap())))
+    Ok(Some(format!(
+        "Hello, {}",
+        args.get_one::<String>("who").unwrap()
+    )))
 }
 
 fn main() -> Result<()> {

--- a/examples/no_context.rs
+++ b/examples/no_context.rs
@@ -4,15 +4,18 @@ use reedline_repl_rs::{Repl, Result};
 
 /// Add two numbers. Have to make this generic to be able to pass a Context of type ()
 fn add<T>(args: ArgMatches, _context: &mut T) -> Result<Option<String>> {
-    let first: i32 = args.value_of("first").unwrap().parse()?;
-    let second: i32 = args.value_of("second").unwrap().parse()?;
+    let first: i32 = args.get_one::<String>("first").unwrap().parse()?;
+    let second: i32 = args.get_one::<String>("second").unwrap().parse()?;
 
     Ok(Some((first + second).to_string()))
 }
 
 /// Write "Hello"
 fn hello<T>(args: ArgMatches, _context: &mut T) -> Result<Option<String>> {
-    Ok(Some(format!("Hello, {}", args.value_of("who").unwrap())))
+    Ok(Some(format!(
+        "Hello, {}",
+        args.get_one::<String>("who").unwrap()
+    )))
 }
 
 fn main() -> Result<()> {

--- a/examples/with_context.rs
+++ b/examples/with_context.rs
@@ -10,7 +10,7 @@ struct Context {
 
 /// Append name to list
 fn append(args: ArgMatches, context: &mut Context) -> Result<Option<String>> {
-    let name: String = args.value_of("name").unwrap().to_string();
+    let name: String = args.get_one::<String>("name").unwrap().to_string();
     context.list.push_back(name);
     let list: Vec<String> = context.list.clone().into();
 
@@ -19,7 +19,7 @@ fn append(args: ArgMatches, context: &mut Context) -> Result<Option<String>> {
 
 /// Prepend name to list
 fn prepend(args: ArgMatches, context: &mut Context) -> Result<Option<String>> {
-    let name: String = args.value_of("name").unwrap().to_string();
+    let name: String = args.get_one::<String>("name").unwrap().to_string();
     context.list.push_front(name);
     let list: Vec<String> = context.list.clone().into();
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 pub(crate) struct ReplCommand<Context, E> {
     pub(crate) name: String,
-    pub(crate) command: Command<'static>,
+    pub(crate) command: Command,
     pub(crate) callback: Option<Callback<Context, E>>,
     #[cfg(feature = "async")]
     pub(crate) async_callback: Option<AsyncCallback<Context, E>>,
@@ -28,7 +28,7 @@ impl<Context, E> PartialEq for ReplCommand<Context, E> {
 
 impl<Context, E> ReplCommand<Context, E> {
     /// Create a new command with the given name and callback function
-    pub fn new(name: &str, command: Command<'static>, callback: Callback<Context, E>) -> Self {
+    pub fn new(name: &str, command: Command, callback: Callback<Context, E>) -> Self {
         Self {
             name: name.to_string(),
             command,
@@ -40,11 +40,7 @@ impl<Context, E> ReplCommand<Context, E> {
 
     /// Create a new async command with the given name and callback function
     #[cfg(feature = "async")]
-    pub fn new_async(
-        name: &str,
-        command: Command<'static>,
-        callback: AsyncCallback<Context, E>,
-    ) -> Self {
+    pub fn new_async(name: &str, command: Command, callback: AsyncCallback<Context, E>) -> Self {
         Self {
             name: name.to_string(),
             command,

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -6,12 +6,12 @@ use crate::{paint_green_bold, paint_yellow_bold, AfterCommandCallback, Callback}
 #[cfg(feature = "async")]
 use crate::{AsyncAfterCommandCallback, AsyncCallback};
 use clap::Command;
-use crossterm::event::{KeyCode, KeyModifiers};
+// use crossterm::event::{KeyCode, KeyModifiers};
 use nu_ansi_term::{Color, Style};
 use reedline::{
-    default_emacs_keybindings, ColumnarMenu, DefaultHinter, DefaultValidator, Emacs,
-    ExampleHighlighter, FileBackedHistory, Keybindings, Reedline, ReedlineEvent, ReedlineMenu,
-    Signal,
+    self, default_emacs_keybindings, ColumnarMenu, DefaultHinter, DefaultValidator, Emacs,
+    ExampleHighlighter, FileBackedHistory, KeyCode, KeyModifiers, Keybindings, Reedline,
+    ReedlineEvent, ReedlineMenu, Signal,
 };
 use std::boxed::Box;
 use std::collections::HashMap;
@@ -261,11 +261,7 @@ where
     }
 
     /// Add a command to your REPL
-    pub fn with_command(
-        mut self,
-        command: Command<'static>,
-        callback: Callback<Context, E>,
-    ) -> Self {
+    pub fn with_command(mut self, command: Command, callback: Callback<Context, E>) -> Self {
         let name = command.get_name().to_string();
         self.commands
             .insert(name.clone(), ReplCommand::new(&name, command, callback));
@@ -276,7 +272,7 @@ where
     #[cfg(feature = "async")]
     pub fn with_command_async(
         mut self,
-        command: Command<'static>,
+        command: Command,
         callback: AsyncCallback<Context, E>,
     ) -> Self {
         let name = command.get_name().to_string();


### PR DESCRIPTION
Hi Folks

Cool project. To see/understand how `reedline-repl-rs` works, I went over the code and made necessary changes to update all dependencies to latest. Some API has changed, notably:

- Clap `value_of` is now `get_one::<String>`
- reedline `Command` does no longer require `static lifetime.
-  `crossterm::event::{KeyCode, KeyModifiers}` are now defined in reedline.

I also updated `Cargo.toml` to version 1.0.2, and the `README.md` to reflect changes.
(I also added that `cargo test` requires the `async` feature, to pass doc-testing.

Besides that, it should be only `rustfmt` stuff that has changed.

Let me know if something more is needed to merge.