### PR TITLE
Custom prompt indicator and timestamp toggle

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -52,9 +52,7 @@ impl Prompt for ReplPrompt {
 
 impl Default for ReplPrompt {
     fn default() -> Self {
-        ReplPrompt::new(
-            "repl",
-        )
+        ReplPrompt::new("repl")
     }
 }
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -6,6 +6,7 @@ pub struct ReplPrompt {
     default: DefaultPrompt,
     prefix: String,
     indicator: String,
+    timestamp: bool
 }
 
 impl Prompt for ReplPrompt {
@@ -16,11 +17,17 @@ impl Prompt for ReplPrompt {
         }
     }
 
-    // call default impl
+    // if timestamp is true, render timestamp on right side of prompt. Otherwise render nothing on right side
     fn render_prompt_right(&self) -> Cow<str> {
-        self.default.render_prompt_right()
+        if self.timestamp {
+            self.default.render_prompt_right()
+        }
+        else {
+            Cow::Borrowed("")
+        }
     }
 
+    // if indicator is empty, use default indicator from reedline. Otherwise use indicator provided
     fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<str> {
         if self.indicator.is_empty() {
             self.default.render_prompt_indicator(edit_mode)
@@ -57,16 +64,20 @@ impl ReplPrompt {
         ReplPrompt {
             prefix: left_prompt.to_string(),
             default: DefaultPrompt::default(),
-            indicator: String::new()
+            indicator: String::new(),
+            timestamp: true
         }
     }
 
-    #[allow(dead_code)]
     pub fn update_prefix(&mut self, prefix: &str) {
         self.prefix = prefix.to_string();
     }
 
     pub fn update_indicator(&mut self, indicator: &str) {
         self.indicator = indicator.to_string();
+    }
+
+    pub fn show_timestamp(&mut self, hide: bool) {
+        self.timestamp = hide;
     }
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 pub struct ReplPrompt {
     default: DefaultPrompt,
     prefix: String,
+    indicator: String,
 }
 
 impl Prompt for ReplPrompt {
@@ -19,12 +20,20 @@ impl Prompt for ReplPrompt {
     fn render_prompt_right(&self) -> Cow<str> {
         self.default.render_prompt_right()
     }
+
     fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<str> {
-        self.default.render_prompt_indicator(edit_mode)
+        if self.indicator.is_empty() {
+            self.default.render_prompt_indicator(edit_mode)
+        }
+        else {
+            Cow::Borrowed(&self.indicator)
+        }
     }
+
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {
         self.default.render_prompt_multiline_indicator()
     }
+
     fn render_prompt_history_search_indicator(
         &self,
         history_search: PromptHistorySearch,
@@ -36,7 +45,9 @@ impl Prompt for ReplPrompt {
 
 impl Default for ReplPrompt {
     fn default() -> Self {
-        ReplPrompt::new("repl")
+        ReplPrompt::new(
+            "repl",
+        )
     }
 }
 
@@ -46,11 +57,16 @@ impl ReplPrompt {
         ReplPrompt {
             prefix: left_prompt.to_string(),
             default: DefaultPrompt::default(),
+            indicator: String::new()
         }
     }
 
     #[allow(dead_code)]
     pub fn update_prefix(&mut self, prefix: &str) {
         self.prefix = prefix.to_string();
+    }
+
+    pub fn update_indicator(&mut self, indicator: &str) {
+        self.indicator = indicator.to_string();
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -63,7 +63,9 @@ where
             KeyCode::Tab,
             ReedlineEvent::Menu("completion_menu".to_string()),
         );
-        let prompt = ReplPrompt::new(&paint_green_bold(&format!("{}> ", name)));
+
+        // possible to get rid of this? 
+        let prompt = ReplPrompt::new(&paint_green_bold(&format!("{name}")));
 
         Self {
             name,
@@ -157,6 +159,12 @@ where
     /// &Paint::green(format!("{}> ", name)).bold().to_string()
     pub fn with_formatted_prompt(mut self, prompt: &str) -> Self {
         self.prompt.update_prefix(prompt);
+
+        self
+    }
+
+    pub fn with_prompt_indicator(mut self, prompt_indicator: &str) -> Self {
+        self.prompt.update_indicator(prompt_indicator);
 
         self
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -64,8 +64,7 @@ where
             ReedlineEvent::Menu("completion_menu".to_string()),
         );
 
-        // possible to get rid of this? 
-        let prompt = ReplPrompt::new(&paint_green_bold(&format!("{name}")));
+        let prompt = ReplPrompt::new(&paint_green_bold(&name));
 
         Self {
             name,
@@ -163,8 +162,16 @@ where
         self
     }
 
+    /// Give your Repl a custom prompt indicator. The default prompt indicator is `〉`
     pub fn with_prompt_indicator(mut self, prompt_indicator: &str) -> Self {
         self.prompt.update_indicator(prompt_indicator);
+
+        self
+    }
+
+    /// Show or hide the timestamp on the right side of the prompt. The default is to show the timestamp.
+    pub fn with_timestamp(mut self, hide_time: bool) -> Self {
+        self.prompt.show_timestamp(hide_time);
 
         self
     }


### PR DESCRIPTION
Hey I love the project but was hoping to customize the prompt just a bit more. Added functions with_prompt_indicator and with_timestamp for the user when making new Repl instances, and by default everything (should) work as it did before if you don't call either of those functions. 

I'm just learning rust so feel free to point me in the right direction if I missed something!