### PR TITLE
Add external-printer from reedline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reedline = "0.27.1"
+reedline = { version = "0.27.1", features = ["external_printer"] }
 nu-ansi-term = { version = "0.49.0" }
 crossterm = { version = "0.27.0" }
 yansi = "0.5.1"

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -262,6 +262,21 @@ where
         self
     }
 
+    /// Access the external printer to print messages on the console
+    ///
+    /// The external printer can be used to print messages on the console without a command running.
+    ///
+    /// Example:
+    ///
+    /// ```rust,no_run
+    /// use reedline_repl_rs::{Repl, Error};
+    /// let mut repl: Repl<(), Error> = Repl::new(());
+    /// let printer = repl.external_printer();
+    /// std::thread::spawn(move || {
+    ///     printer.print("hello world".to_owned()).expect("failed to print");
+    /// });
+    /// repl.run().expect("failed to run");
+    /// ```
     pub fn external_printer(&self) -> ExternalPrinter<String> {
         self.external_printer.clone()
     }


### PR DESCRIPTION
This should fix #32

It allows for displaying messages on the console even when no command is running (such as events or other messages).

`reedline` uses crossbeam for the `Sender` of the `ExternalPrinter`, which is not ideal for async code. I did expose the `ExternalPrinter` directly as this avoids a direct dependency of this crate on crossbeam. However, for the `async` feature of this crate, the `ExternalPrinter` implementation of `reedline` is not ideal. But as the `ExternalPrinter` is not a trait, I think we have to use it as is.