### PR TITLE
added for async_derived feature along with example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ async = []
 scripts = []
 macro = ["clap/cargo"]
 derive = ["clap/derive"]
+async_derive = ["async", "derive"]
 
 [[example]]
 name = "async"
@@ -67,3 +68,8 @@ required-features = ["derive"]
 name = "derive_with_context"
 path = "examples/derive/with_context.rs"
 required-features = ["derive"]
+
+[[example]]
+name = "dervice_async"
+path = "examples/derive/async.rs"
+required-features = ["async_derive"]

--- a/examples/derive/async.rs
+++ b/examples/derive/async.rs
@@ -1,0 +1,36 @@
+//! Minimal example
+use std::collections::HashMap;
+
+use reedline_repl_rs::clap::{ArgMatches, Parser};
+use reedline_repl_rs::{AsyncCallBackMap, Repl, Result};
+
+#[derive(Parser, Debug)]
+#[command(name = "MyApp", version = "v0.1.0", about = "My very cool app")]
+pub enum MyApp {
+    /// Greeting
+    Hello { who: String },
+}
+
+/// Write "Hello" with given name
+async fn hello<T>(args: ArgMatches, _context: &mut T) -> Result<Option<String>> {
+    Ok(Some(format!(
+        "Hello, {}",
+        args.get_one::<String>("who").unwrap()
+    )))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut callbacks: AsyncCallBackMap<(), reedline_repl_rs::Error> = HashMap::new();
+
+    callbacks.insert("hello".to_string(), |args, context| {
+        Box::pin(hello(args, context))
+    });
+
+    let mut repl = Repl::new(())
+        .with_name("MyApp")
+        .with_version("v0.1.0")
+        .with_async_derived::<MyApp>(callbacks);
+
+    repl.run_async().await
+}

--- a/examples/derive/hello_world.rs
+++ b/examples/derive/hello_world.rs
@@ -1,7 +1,6 @@
 //! Minimal example
 use std::collections::HashMap;
 
-use clap::Subcommand;
 use reedline_repl_rs::clap::{ArgMatches, Parser};
 use reedline_repl_rs::{CallBackMap, Repl, Result};
 

--- a/examples/derive/subcommands.rs
+++ b/examples/derive/subcommands.rs
@@ -1,8 +1,8 @@
 //! Subcommands example
 use std::collections::HashMap;
 
-use clap::{arg, command, Parser, Subcommand, ValueEnum};
-use reedline_repl_rs::clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{arg, command, Parser, Subcommand};
+use reedline_repl_rs::clap::{ArgAction, ArgMatches};
 use reedline_repl_rs::{CallBackMap, Repl, Result};
 
 #[derive(Parser, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,10 @@ pub type Callback<Context, Error> =
 #[allow(dead_code)]
 type CommandName = String;
 
+#[cfg(feature = "async_derive")]
+pub type AsyncCallBackMap<Context, Error> =
+    std::collections::HashMap<CommandName, AsyncCallback<Context, Error>>;
+
 #[cfg(feature = "derive")]
 pub type CallBackMap<Context, Error> =
     std::collections::HashMap<CommandName, Callback<Context, Error>>;


### PR DESCRIPTION
added support for async callbacks when using derive along with example and fixed some unused import warnings with other examples.

Thanks for the library! I was using the derive feature until I needed to add a async callbacks as well. Thanks to the people who made the derive and async features. it made my job easy :) 