### PR TITLE
Support arguments with escaping.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ crossterm = { version = "0.27.0" }
 yansi = "1.0.1"
 regex = "1.10.4"
 clap = "4.5.4"
+shell-words = "1.1.0"
 
 [dev-dependencies]
 tokio = { version = "1.37.0", features = [

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -492,11 +492,7 @@ where
     }
 
     fn parse_line(&self, line: &str) -> (String, Vec<String>) {
-        let r = regex::Regex::new(r#"("[^"\n]+"|[\S]+)"#).unwrap();
-        let mut args = r
-            .captures_iter(line)
-            .map(|a| a[0].to_string().replace('\"', ""))
-            .collect::<Vec<String>>();
+        let mut args = shell_words::split(line).unwrap();
         let command: String = args.drain(..1).collect();
         (command, args)
     }


### PR DESCRIPTION
The current implementation doesn't support escaping in parameters. For example, if one wants to introduce a command
that takes json as one of the argument, and call it like this:
```
execute "my query" "{\"body\": \"value\"}"
```
It would parse the arguments incorrectly. This little PR fixes that by using the `shell-words` crate that has parsing rules similar to Unix shell.

Originally, I used this fix in my little pet-project implementation, but given that I had to switch to a different repl library (more to do with reedline itself, rather than this this project), I didn't introduce any tests for that. But posting it here in case it still would be beneficial.