### PR TITLE
Add optional shlex splitter and public process_argv method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reedline-repl-rs"
-version = "1.1.1"
+version = "1.2.0"
 authors = [
     "Artur Hallmann <arturh@arturh.de>",
     "Jack Lund <jackl@geekheads.net>",
@@ -23,6 +23,7 @@ crossterm = { version = "0.27.0" }
 yansi = "1.0.1"
 regex = "1.10.4"
 clap = "4.5.4"
+shlex = {  version = "1.3.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.37.0", features = [

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Features:
 - Configurable prompt with hooks to update after commands run
 - Command Syntax highlighting 
 - Feature-flag for async support
+- Feature-flag `shlex` for optional POSIX compliant line splitting
 - Tip: Search history with `CTRL+R`, clear input with `CTRL+C`, exit repl with `CTRL+D` 
 
 Basic example code:


### PR DESCRIPTION
This change allows a use case where we want to run REPL if our program is executed without commandline parameters, or interpret the commandline parameters as input to execute a single command if present.

To have compatible line splitting behavior between both use cases, we optionally use shlex::split() to split REPL inputs.

This example demonstrates such use:
```rust

let mut repl = reedline_repl_rs::Repl::new(());
// ... set up repl ...
if std::env::args().len() > 1 {
    repl.process_argv(std::env::args().skip(1).collect::<Vec<String>>())?;
} else {
    run()?;
}
```

Version is bumped to 1.2.0 as this adds a new backwards compatible feature.