### PR TITLE
Allow retrieving the context from a `Repl`

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -371,6 +371,21 @@ where
         self
     }
 
+    /// Immutably borrows the context.
+    pub fn context(&self) -> &Context {
+        &self.context
+    }
+
+    /// Mutably borrows the context.
+    pub fn context_mut(&mut self) -> &mut Context {
+        &mut self.context
+    }
+
+    /// Consumes the `Repl`, returning the wrapped context.
+    pub fn into_context(self) -> Context {
+        self.context
+    }
+
     fn show_help(&self, args: &[&str]) -> Result<()> {
         if args.is_empty() {
             let mut app = Command::new("app");


### PR DESCRIPTION
This is convenient for interacting with the context after `run()` returns, or between `run_with_reader()` or `process_argv()` invocations.