### PR TITLE
Improvements to top-level help output

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -2,7 +2,7 @@ use crate::command::ReplCommand;
 use crate::completer::ReplCompleter;
 use crate::error::*;
 use crate::prompt::ReplPrompt;
-use crate::{paint_green_bold, paint_yellow_bold, AfterCommandCallback, Callback};
+use crate::{paint_green_bold, AfterCommandCallback, Callback};
 #[cfg(feature = "async")]
 use crate::{AsyncAfterCommandCallback, AsyncCallback};
 use clap::Command;
@@ -373,27 +373,16 @@ where
 
     fn show_help(&self, args: &[&str]) -> Result<()> {
         if args.is_empty() {
-            let mut app = Command::new("app");
-
+            let mut app = Command::new("app").help_template("{usage-heading}\n{subcommands}");
             for (_, com) in self.commands.iter() {
                 app = app.subcommand(com.command.clone());
-            }
-            let mut help_bytes: Vec<u8> = Vec::new();
-            app.write_help(&mut help_bytes)
-                .expect("failed to print help");
-            let mut help_string =
-                String::from_utf8(help_bytes).expect("Help message was invalid UTF8");
-            let marker = "SUBCOMMANDS:";
-            if let Some(marker_pos) = help_string.find(marker) {
-                help_string = paint_yellow_bold("COMMANDS:")
-                    + &help_string[(marker_pos + marker.len())..help_string.len()];
             }
             println!("{} {}", paint_green_bold(&self.name), self.version);
             if !self.description.is_empty() {
                 println!("{}", self.description);
             }
             println!();
-            println!("{}", help_string);
+            app.print_help().expect("failed to print help");
         } else if let Some((_, subcommand)) = self
             .commands
             .iter()

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -388,13 +388,11 @@ where
                 help_string = paint_yellow_bold("COMMANDS:")
                     + &help_string[(marker_pos + marker.len())..help_string.len()];
             }
-            let header = format!(
-                "{} {}\n{}\n",
-                paint_green_bold(&self.name),
-                self.version,
-                self.description
-            );
-            println!("{}", header);
+            println!("{} {}", paint_green_bold(&self.name), self.version);
+            if !self.description.is_empty() {
+                println!("{}", self.description);
+            }
+            println!();
             println!("{}", help_string);
         } else if let Some((_, subcommand)) = self
             .commands

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -374,8 +374,10 @@ where
     fn show_help(&self, args: &[&str]) -> Result<()> {
         if args.is_empty() {
             let mut app = Command::new("app").help_template("{usage-heading}\n{subcommands}");
-            for (_, com) in self.commands.iter() {
-                app = app.subcommand(com.command.clone());
+            let mut names = self.commands.keys().collect::<Vec<&String>>();
+            names.sort();
+            for name in names {
+                app = app.subcommand(self.commands.get(name).unwrap().command.clone());
             }
             println!("{} {}", paint_green_bold(&self.name), self.version);
             if !self.description.is_empty() {


### PR DESCRIPTION
clap reformatted its help text so our postprocessing no longer works properly.  Use clap's help template functionality to just ask for what we want.

List command names in alphabetical order in help.  The order was different on every run because `HashMap`'s hash algorithm uses a random seed.

Avoid an extra blank line in help if the `Repl`'s description is empty.
    
Fixes: #66